### PR TITLE
Update watir-screenshot-stitch.rb

### DIFF
--- a/lib/watir-screenshot-stitch.rb
+++ b/lib/watir-screenshot-stitch.rb
@@ -93,10 +93,9 @@ module Watir
         %<
           function genScreenshot () {
             var canvasImgContentDecoded;
-            html2canvas(document.body, {
-              onrendered: function (canvas) {
-               window.canvasImgContentDecoded = canvas.toDataURL("image/png");
-            }});
+          html2canvas(document.body).then(function (canvas) {
+             window.canvasImgContentDecoded = canvas.toDataURL("image/png");
+          });
           };
           genScreenshot();
         >.gsub(/\s+/, ' ').strip


### PR DESCRIPTION
onrendered option is deprecated, replacing it with .then fixes the error and generates output image.